### PR TITLE
move Joi from dev to normal dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/seangenabe/etagger#readme",
   "dependencies": {
-    "json-stable-stringify": "^1.0.1"
+    "json-stable-stringify": "^1.0.1",
+    "joi": "^11.0.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",
@@ -40,7 +41,6 @@
     "coveralls": "^3.0.0",
     "cross-env": "^5.0.0",
     "hapi": "^16.1.1",
-    "joi": "^11.0.0",
     "nyc": "^11.0.1"
   },
   "nyc": {


### PR DESCRIPTION
if project using this plugin doesn't already use Joi `require('etagger')` will result in `Error: Cannot find module 'joi'`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seangenabe/etagger/29)
<!-- Reviewable:end -->
